### PR TITLE
Add supervisor organization management

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -14,8 +14,6 @@ interface User {
 export default function DashboardPage() {
   const router = useRouter();
   const [user, setUser] = useState<User | null>(null);
-  const [org, setOrg] = useState({ title: "", inn: "" });
-  const [message, setMessage] = useState("");
 
   useEffect(() => {
     const token = localStorage.getItem("token");
@@ -28,17 +26,6 @@ export default function DashboardPage() {
       .then((res) => setUser(res.data))
       .catch(() => router.push("/login"));
   }, [router]);
-
-  const createOrg = async (e: React.FormEvent) => {
-    e.preventDefault();
-    try {
-      await api.post("/api/organization", org);
-      setMessage("Organization created");
-      setOrg({ title: "", inn: "" });
-    } catch {
-      setMessage("Creation failed");
-    }
-  };
 
   return (
     <div>
@@ -56,25 +43,6 @@ export default function DashboardPage() {
           </p>
         </div>
       )}
-      <form onSubmit={createOrg} className="flex flex-col gap-2 max-w-md">
-        <h2 className="text-xl font-semibold">Create organization</h2>
-        <input
-          className="border p-2"
-          placeholder="Title"
-          value={org.title}
-          onChange={(e) => setOrg({ ...org, title: e.target.value })}
-        />
-        <input
-          className="border p-2"
-          placeholder="INN"
-          value={org.inn}
-          onChange={(e) => setOrg({ ...org, inn: e.target.value })}
-        />
-        <button type="submit" className="bg-green-600 text-white py-2">
-          Create
-        </button>
-        {message && <p className="text-sm mt-1">{message}</p>}
-      </form>
     </div>
   );
 }

--- a/src/app/organizations/page.tsx
+++ b/src/app/organizations/page.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { api } from "@/lib/api";
+
+interface Organization {
+  id: number;
+  title: string;
+  inn: string;
+}
+
+export default function OrganizationsPage() {
+  const router = useRouter();
+  const [orgs, setOrgs] = useState<Organization[]>([]);
+  const [form, setForm] = useState({ title: "", inn: "" });
+  const [message, setMessage] = useState("");
+
+  const load = async () => {
+    try {
+      const res = await api.get("/api/organization");
+      setOrgs(res.data);
+    } catch {
+      setOrgs([]);
+    }
+  };
+
+  useEffect(() => {
+    api
+      .get("/api/me")
+      .then((res) => {
+        if (res.data.role !== "SUPERVISOR") {
+          router.push("/dashboard");
+          return;
+        }
+        load();
+      })
+      .catch(() => router.push("/login"));
+  }, [router]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const createOrg = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await api.post("/api/organization", form);
+      setMessage("Organization created");
+      setForm({ title: "", inn: "" });
+      load();
+    } catch {
+      setMessage("Creation failed");
+    }
+  };
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">My Organizations</h1>
+      <table className="min-w-full border mb-6">
+        <thead>
+          <tr>
+            <th className="border px-2">Title</th>
+            <th className="border px-2">INN</th>
+          </tr>
+        </thead>
+        <tbody>
+          {orgs.map((o) => (
+            <tr key={o.id}>
+              <td className="border px-2">{o.title}</td>
+              <td className="border px-2">{o.inn}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <form onSubmit={createOrg} className="flex flex-col gap-2 max-w-md">
+        <h2 className="text-xl font-semibold">Create organization</h2>
+        <input
+          name="title"
+          className="border p-2"
+          placeholder="Title"
+          value={form.title}
+          onChange={handleChange}
+        />
+        <input
+          name="inn"
+          className="border p-2"
+          placeholder="INN"
+          value={form.inn}
+          onChange={handleChange}
+        />
+        <button type="submit" className="bg-green-600 text-white py-2">
+          Create
+        </button>
+        {message && <p className="text-sm mt-1">{message}</p>}
+      </form>
+    </div>
+  );
+}

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -17,8 +17,17 @@ export default function UsersPage() {
 
   useEffect(() => {
     api
-      .get("/admin/users")
-      .then((res) => setUsers(res.data))
+      .get("/api/me")
+      .then((res) => {
+        if (res.data.role !== "ADMIN") {
+          router.push("/dashboard");
+          return;
+        }
+        api
+          .get("/admin/users")
+          .then((r) => setUsers(r.data))
+          .catch(() => router.push("/login"));
+      })
       .catch(() => router.push("/login"));
   }, [router]);
 

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -3,13 +3,22 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
 
 export default function NavBar() {
   const router = useRouter();
   const [token, setToken] = useState<string | null>(null);
+  const [role, setRole] = useState<string | null>(null);
 
   useEffect(() => {
-    setToken(localStorage.getItem("token"));
+    const stored = localStorage.getItem("token");
+    setToken(stored);
+    if (stored) {
+      api
+        .get("/api/me")
+        .then((res) => setRole(res.data.role))
+        .catch(() => setRole(null));
+    }
   }, []);
 
   if (!token) {
@@ -26,9 +35,16 @@ export default function NavBar() {
       <Link href="/dashboard" className="hover:underline">
         Dashboard
       </Link>
-      <Link href="/users" className="hover:underline">
-        Users
-      </Link>
+      {role === "SUPERVISOR" && (
+        <Link href="/organizations" className="hover:underline">
+          Organizations
+        </Link>
+      )}
+      {role === "ADMIN" && (
+        <Link href="/users" className="hover:underline">
+          Users
+        </Link>
+      )}
       <button onClick={logout} className="ml-auto hover:underline">
         Logout
       </button>


### PR DESCRIPTION
## Summary
- add role-based navigation and restrict admin/supervisor pages
- create supervisor organizations page to view and create own organizations
- simplify dashboard by removing organization creation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689c8a726cd08333aac503b5072e0874