### PR TITLE
feat: align frontend with backend changes

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -22,16 +22,16 @@ export default function DashboardPage() {
       return;
     }
     api
-      .get("/api/me")
+      .get("/api/users/me")
       .then((res) => setUser(res.data))
       .catch(() => router.push("/login"));
   }, [router]);
 
   return (
-    <div>
+    <div className="max-w-xl mx-auto mt-10 bg-white p-6 rounded-lg shadow-md">
       <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
       {user && (
-        <div className="mb-6">
+        <div className="space-y-2">
           <p>
             <strong>Username:</strong> {user.username}
           </p>

--- a/src/app/employees/page.tsx
+++ b/src/app/employees/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { api } from "@/lib/api";
+
+export default function EmployeesPage() {
+  const router = useRouter();
+  const [form, setForm] = useState({ email: "", password: "" });
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    api
+      .get("/api/users/me")
+      .then((res) => {
+        if (res.data.role !== "SUPERVISOR") {
+          router.push("/dashboard");
+        }
+      })
+      .catch(() => router.push("/login"));
+  }, [router]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const createEmployee = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await api.post("/api/employees", {
+        email: form.email,
+        password: form.password,
+      });
+      setMessage("Employee created");
+      setForm({ email: "", password: "" });
+    } catch {
+      setMessage("Creation failed");
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto mt-10 bg-white p-6 rounded-lg shadow-md">
+      <h1 className="text-2xl font-bold mb-4">Create employee</h1>
+      <form onSubmit={createEmployee} className="flex flex-col gap-4">
+        <input
+          name="email"
+          type="email"
+          placeholder="Email"
+          value={form.email}
+          onChange={handleChange}
+          className="border p-2 rounded"
+        />
+        <input
+          name="password"
+          type="password"
+          placeholder="Password"
+          value={form.password}
+          onChange={handleChange}
+          className="border p-2 rounded"
+        />
+        <button type="submit" className="bg-green-600 text-white py-2 rounded">
+          Create
+        </button>
+        {message && <p className="text-sm mt-1">{message}</p>}
+      </form>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,24 +1,25 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
   --foreground: #171717;
 }
 
 @theme inline {
-  --color-background: var(--background);
   --color-foreground: var(--foreground);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
     --foreground: #ededed;
+  }
+  body {
+    background: linear-gradient(to bottom right, #0a0a0a, #1f1f1f);
   }
 }
 
 body {
-  background: var(--background);
+  min-height: 100vh;
+  background: linear-gradient(to bottom right, #f0f4f8, #d9e2ec);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -22,7 +22,7 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="max-w-md mx-auto mt-10">
+    <div className="max-w-md mx-auto mt-10 bg-white p-6 rounded-lg shadow-md">
       <h1 className="text-2xl font-bold mb-4">Login</h1>
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
         <input
@@ -30,17 +30,19 @@ export default function LoginPage() {
           placeholder="Username"
           value={username}
           onChange={(e) => setUsername(e.target.value)}
-          className="border p-2"
+          className="border p-2 rounded"
         />
         <input
           type="password"
           placeholder="Password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
-          className="border p-2"
+          className="border p-2 rounded"
         />
         {error && <p className="text-red-500 text-sm">{error}</p>}
-        <button type="submit" className="bg-blue-600 text-white py-2">Login</button>
+        <button type="submit" className="bg-blue-600 text-white py-2 rounded">
+          Login
+        </button>
       </form>
       <p className="mt-4 text-sm">
         No account? <a href="/register" className="text-blue-600">Register</a>

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -7,14 +7,12 @@ import { api } from "@/lib/api";
 export default function RegisterPage() {
   const router = useRouter();
   const [form, setForm] = useState({
-    username: "",
     email: "",
     password: "",
-    role: "SUPERVISOR",
   });
   const [error, setError] = useState<string | null>(null);
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value });
   };
 
@@ -29,24 +27,16 @@ export default function RegisterPage() {
   };
 
   return (
-    <div className="max-w-md mx-auto mt-10">
+    <div className="max-w-md mx-auto mt-10 bg-white p-6 rounded-lg shadow-md">
       <h1 className="text-2xl font-bold mb-4">Register</h1>
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-        <input
-          name="username"
-          type="text"
-          placeholder="Username"
-          value={form.username}
-          onChange={handleChange}
-          className="border p-2"
-        />
         <input
           name="email"
           type="email"
           placeholder="Email"
           value={form.email}
           onChange={handleChange}
-          className="border p-2"
+          className="border p-2 rounded"
         />
         <input
           name="password"
@@ -54,19 +44,12 @@ export default function RegisterPage() {
           placeholder="Password"
           value={form.password}
           onChange={handleChange}
-          className="border p-2"
+          className="border p-2 rounded"
         />
-        <select
-          name="role"
-          value={form.role}
-          onChange={handleChange}
-          className="border p-2"
-        >
-          <option value="SUPERVISOR">Supervisor</option>
-          <option value="ADMIN">Admin</option>
-        </select>
         {error && <p className="text-red-500 text-sm">{error}</p>}
-        <button type="submit" className="bg-blue-600 text-white py-2">Register</button>
+        <button type="submit" className="bg-blue-600 text-white py-2 rounded">
+          Register
+        </button>
       </form>
       <p className="mt-4 text-sm">
         Already have an account? <a href="/login" className="text-blue-600">Login</a>

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -17,7 +17,7 @@ export default function UsersPage() {
 
   useEffect(() => {
     api
-      .get("/api/me")
+      .get("/api/users/me")
       .then((res) => {
         if (res.data.role !== "ADMIN") {
           router.push("/dashboard");
@@ -32,22 +32,22 @@ export default function UsersPage() {
   }, [router]);
 
   return (
-    <div>
+    <div className="max-w-2xl mx-auto mt-10 bg-white p-6 rounded-lg shadow-md">
       <h1 className="text-2xl font-bold mb-4">Users</h1>
-      <table className="min-w-full border">
-        <thead>
+      <table className="min-w-full border rounded">
+        <thead className="bg-gray-100">
           <tr>
-            <th className="border px-2">Username</th>
-            <th className="border px-2">Email</th>
-            <th className="border px-2">Role</th>
+            <th className="border px-2 py-1">Username</th>
+            <th className="border px-2 py-1">Email</th>
+            <th className="border px-2 py-1">Role</th>
           </tr>
         </thead>
         <tbody>
           {users.map((u) => (
-            <tr key={u.id}>
-              <td className="border px-2">{u.username}</td>
-              <td className="border px-2">{u.email}</td>
-              <td className="border px-2">{u.role}</td>
+            <tr key={u.id} className="odd:bg-white even:bg-gray-50">
+              <td className="border px-2 py-1">{u.username}</td>
+              <td className="border px-2 py-1">{u.email}</td>
+              <td className="border px-2 py-1">{u.role}</td>
             </tr>
           ))}
         </tbody>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -15,7 +15,7 @@ export default function NavBar() {
     setToken(stored);
     if (stored) {
       api
-        .get("/api/me")
+        .get("/api/users/me")
         .then((res) => setRole(res.data.role))
         .catch(() => setRole(null));
     }
@@ -31,14 +31,19 @@ export default function NavBar() {
   };
 
   return (
-    <nav className="bg-gray-800 text-white p-4 flex gap-4">
+    <nav className="bg-gradient-to-r from-indigo-600 to-purple-600 text-white p-4 flex gap-4 shadow-md">
       <Link href="/dashboard" className="hover:underline">
         Dashboard
       </Link>
       {role === "SUPERVISOR" && (
-        <Link href="/organizations" className="hover:underline">
-          Organizations
-        </Link>
+        <>
+          <Link href="/organizations" className="hover:underline">
+            Organizations
+          </Link>
+          <Link href="/employees" className="hover:underline">
+            Employees
+          </Link>
+        </>
       )}
       {role === "ADMIN" && (
         <Link href="/users" className="hover:underline">


### PR DESCRIPTION
## Summary
- use updated `/api/users/me` endpoint across the app
- add employee creation page for supervisors
- refresh styling with gradient background and card-like forms

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a60fc675448333a708568bcf9c4a51