### PR TITLE
Use dedicated endpoint to load user organizations

### DIFF
--- a/src/app/organizations/page.tsx
+++ b/src/app/organizations/page.tsx
@@ -22,7 +22,8 @@ export default function OrganizationsPage() {
         router.push("/dashboard");
         return;
       }
-      setOrgs(res.data.organizationsResponses || []);
+      const orgsRes = await api.get("/api/organization");
+      setOrgs(orgsRes.data || []);
     } catch {
       router.push("/login");
     }


### PR DESCRIPTION
## Summary
- Fetch organizations via new `/api/organization` endpoint instead of relying on `/api/users/me`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a616bd26408333b1ca84c0a5346b23