### PR TITLE
feat: add organization employees view

### DIFF
--- a/src/app/organizations/[id]/page.tsx
+++ b/src/app/organizations/[id]/page.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter, useParams } from "next/navigation";
+import { api } from "@/lib/api";
+
+interface Employee {
+  id: number;
+  email: string;
+}
+
+interface Organization {
+  id: number;
+  title: string;
+  inn: string;
+  employees: Employee[];
+}
+
+export default function OrganizationPage() {
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const id = params.id;
+  const [org, setOrg] = useState<Organization | null>(null);
+  const [form, setForm] = useState({ email: "", password: "" });
+  const [message, setMessage] = useState("");
+
+  const load = useCallback(async () => {
+    try {
+      const me = await api.get("/api/users/me");
+      if (me.data.role !== "SUPERVISOR") {
+        router.push("/dashboard");
+        return;
+      }
+      const res = await api.get(`/api/organization/${id}`);
+      setOrg(res.data);
+    } catch {
+      router.push("/login");
+    }
+  }, [id, router]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const createEmployee = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await api.post(`/api/organization/${id}/employees`, {
+        email: form.email,
+        password: form.password,
+      });
+      setMessage("Работник создан");
+      setForm({ email: "", password: "" });
+      load();
+    } catch {
+      setMessage("Ошибка создания");
+    }
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto mt-10 bg-white p-6 rounded-lg shadow-md">
+      {org && (
+        <>
+          <h1 className="text-2xl font-bold mb-4">{org.title}</h1>
+          <h2 className="text-xl font-semibold mb-2">Работники</h2>
+          <table className="min-w-full border mb-6 rounded">
+            <thead className="bg-gray-100">
+              <tr>
+                <th className="border px-2 py-1">ID</th>
+                <th className="border px-2 py-1">Email</th>
+              </tr>
+            </thead>
+            <tbody>
+              {org.employees.map((e) => (
+                <tr key={e.id} className="odd:bg-white even:bg-gray-50">
+                  <td className="border px-2 py-1">{e.id}</td>
+                  <td className="border px-2 py-1">{e.email}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+      <form onSubmit={createEmployee} className="flex flex-col gap-2 max-w-md">
+        <h2 className="text-xl font-semibold">Создать работника</h2>
+        <input
+          name="email"
+          type="email"
+          className="border p-2 rounded"
+          placeholder="Электронная почта"
+          value={form.email}
+          onChange={handleChange}
+        />
+        <input
+          name="password"
+          type="password"
+          className="border p-2 rounded"
+          placeholder="Пароль"
+          value={form.password}
+          onChange={handleChange}
+        />
+        <button type="submit" className="bg-green-600 text-white py-2 rounded">
+          Создать
+        </button>
+        {message && <p className="text-sm mt-1">{message}</p>}
+      </form>
+    </div>
+  );
+}
+

--- a/src/app/organizations/page.tsx
+++ b/src/app/organizations/page.tsx
@@ -44,27 +44,31 @@ export default function OrganizationsPage() {
         title: form.title,
         inn: Number(form.inn),
       });
-      setMessage("Organization created");
+      setMessage("Организация создана");
       setForm({ title: "", inn: "" });
       load();
     } catch {
-      setMessage("Creation failed");
+      setMessage("Ошибка создания");
     }
   };
 
   return (
     <div className="max-w-2xl mx-auto mt-10 bg-white p-6 rounded-lg shadow-md">
-      <h1 className="text-2xl font-bold mb-4">My Organizations</h1>
+      <h1 className="text-2xl font-bold mb-4">Мои организации</h1>
       <table className="min-w-full border mb-6 rounded">
         <thead className="bg-gray-100">
           <tr>
-            <th className="border px-2 py-1">Title</th>
-            <th className="border px-2 py-1">INN</th>
+            <th className="border px-2 py-1">Название</th>
+            <th className="border px-2 py-1">ИНН</th>
           </tr>
         </thead>
         <tbody>
           {orgs.map((o) => (
-            <tr key={o.id} className="odd:bg-white even:bg-gray-50">
+            <tr
+              key={o.id}
+              onClick={() => router.push(`/organizations/${o.id}`)}
+              className="odd:bg-white even:bg-gray-50 cursor-pointer hover:bg-gray-100"
+            >
               <td className="border px-2 py-1">{o.title}</td>
               <td className="border px-2 py-1">{o.inn}</td>
             </tr>
@@ -72,23 +76,23 @@ export default function OrganizationsPage() {
         </tbody>
       </table>
       <form onSubmit={createOrg} className="flex flex-col gap-2 max-w-md">
-        <h2 className="text-xl font-semibold">Create organization</h2>
+        <h2 className="text-xl font-semibold">Создать организацию</h2>
         <input
           name="title"
           className="border p-2 rounded"
-          placeholder="Title"
+          placeholder="Название"
           value={form.title}
           onChange={handleChange}
         />
         <input
           name="inn"
           className="border p-2 rounded"
-          placeholder="INN"
+          placeholder="ИНН"
           value={form.inn}
           onChange={handleChange}
         />
         <button type="submit" className="bg-green-600 text-white py-2 rounded">
-          Create
+          Создать
         </button>
         {message && <p className="text-sm mt-1">{message}</p>}
       </form>


### PR DESCRIPTION
## Summary
- make organizations list clickable and translate labels to Russian
- add organization page to show employees and allow creation

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68a8766e770c8333bc927cdb1004db3f