### PR TITLE
use new employees/getAll API with filter

### DIFF
--- a/src/app/employees/page.tsx
+++ b/src/app/employees/page.tsx
@@ -22,7 +22,9 @@ export default function EmployeesPage() {
         router.push("/dashboard");
         return;
       }
-      const employeesRes = await api.get("/api/employees");
+      const employeesRes = await api.post("/api/employees/getAll", {
+        filter: {},
+      });
       setEmployees(employeesRes.data || []);
     } catch {
       router.push("/login");

--- a/src/app/organizations/[id]/page.tsx
+++ b/src/app/organizations/[id]/page.tsx
@@ -31,8 +31,11 @@ export default function OrganizationPage() {
         router.push("/dashboard");
         return;
       }
-      const res = await api.get(`/api/organization/${id}`);
-      setOrg({ ...res.data, employees: res.data.employees || [] });
+      const orgRes = await api.get(`/api/organization/${id}`);
+      const employeesRes = await api.post("/api/employees/getAll", {
+        filter: { organizationId: Number(id) },
+      });
+      setOrg({ ...orgRes.data, employees: employeesRes.data || [] });
     } catch {
       router.push("/login");
     }


### PR DESCRIPTION
## Summary
- switch employee list requests to `employees/getAll`
- fetch organization employees using the new filtered endpoint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68a88ebabd888333afe3ede370da79f8